### PR TITLE
Adaptation for AHK 2.0, optimization for non-standard layouts and error correction

### DIFF
--- a/mouse-control.ahk
+++ b/mouse-control.ahk
@@ -127,6 +127,7 @@ ShowModePopup(msg) {
     HideTrayTip()
     TrayTip(msg, "Mouse control", "Mute")
     SetTimer(HideTrayTip, 2000) ; Let it display for 2 seconds.
+    SetTimer(HideTrayTip, 0)
 }
 
 HideTrayTip() {
@@ -356,7 +357,8 @@ SC020:: return ; d
 +SC01E:: JumpToEdge("left") ; shift + a
 +SC01F:: JumpToEdge("bottom") ; shift + s
 +SC020:: JumpToEdge("right") ; shift + d
-*SC012:: ScrollTo("down") ; e
+; *SC012:: ScrollTo("down") ; e
+h & h:: ScrollTo("down", 5) ; e
 *SC010:: ScrollTo("up") ; q
 *SC013:: MouseClick() ; r
 SC014:: MouseClick("R") ; t
@@ -368,10 +370,10 @@ SC014:: MouseClick("R") ; t
 ; MButton:: ReleaseDrag(2)
 ; RButton:: ReleaseDrag(3)
 
-; FUTURE CONSIDERATIONS
-; AwaitKey function for vimesque multi keystroke commands (gg, yy, 2M, etc)
-; "Marks" for remembering and restoring mouse positions (needs AwaitKey)
-; v to let go of mouse when mouse is down with v (lemme crop in Paint.exe)
-; z for click and release middle mouse? this has historically not worked well
-; c guess that leaves c for hold / release right mouse (x is useful in chromium)
-; Whatever you can think of! Github issues and pull requests welcome
+; TODO: AwaitKey function for vimesque multi keystroke commands (gg, yy, 2M, etc)
+; TODO: "Marks" for remembering and restoring mouse positions (needs AwaitKey)
+; TODO: v to let go of mouse when mouse is down with v (lemme crop in Paint.exe)
+; ?TODO: z for click and release middle mouse? this has historically not worked well
+; ?TODO: c guess that leaves c for hold / release right mouse (x is useful in chromium)
+;
+; Github issues and pull requests welcome

--- a/mouse-control.ahk
+++ b/mouse-control.ahk
@@ -7,9 +7,6 @@ InstallKeybdHook
 ; Astrid Ivy
 ; 2019-04-14
 
-; TODO сделать красивым
-modeModal := Gui(, "Mode")
-
 global INSERT_MODE := false
 global INSERT_QUICK := false
 global NORMAL_MODE := false
@@ -23,6 +20,7 @@ global VELOCITY_X := 0
 global VELOCITY_Y := 0
 
 global DRAGGING := false
+global SLEEP_TIMER := 0
 
 ; Insert Mode by default
 EnterInsertMode()
@@ -88,7 +86,6 @@ EnterNormalMode(quick := false, mode := "vim") {
     msg := quick
         ? msg . " (QUICK)" : msg . ""
 
-    ; TODO если удерживать то будет дублировать
     ShowModePopup(msg)
 
     if (NORMAL_MODE) {
@@ -119,7 +116,6 @@ ClickInsert(quick := true) {
     EnterInsertMode(quick)
 }
 
-; TODO doesn't really work well
 DoubleClickInsert(quick := true) {
     Click
     Sleep(100)
@@ -128,16 +124,19 @@ DoubleClickInsert(quick := true) {
 }
 
 ShowModePopup(msg) {
-    ; clean up any lingering popups
-    ClosePopup()
-    modeModal.AddText(, msg)
-    modeModal.Show("AutoSize")
-
-    SetTimer(ClosePopup, -1300)
+    HideTrayTip()
+    TrayTip(msg, "Mouse control", "Mute")
+    SetTimer(HideTrayTip, 2000) ; Let it display for 2 seconds.
 }
 
-ClosePopup() {
-    modeModal.Hide()
+HideTrayTip() {
+    TrayTip  ; Attempt to hide it the normal way.
+
+    if SubStr(A_OSVersion, 1, 3) = "10." {
+        A_IconHidden := true
+        Sleep 200  ; It may be necessary to adjust this sleep.
+        A_IconHidden := false
+    }
 }
 
 Drag(mouseButton := "L") {
@@ -296,12 +295,13 @@ SC032:: JumpMiddle() ; m
 SC031:: MouseBrowserNavigate("forward") ; n
 SC030:: MouseBrowserNavigate("back") ; b
 ; TODO allow for modifier keys (or more importantly a lack of them) by lifting ctrl requirement for these hotkeys
+;? fixed?
 *SC00A:: ScrollTo("up") ; 9
 *SC00B:: ScrollTo("down") ; 0
 SC01A:: ScrollTo("up") ; [
-+SC01A:: ScrollTo("up", 4) ; TODO not working
+#SC01A:: ScrollTo("up", 4) ; win + [
 SC01B:: ScrollTo("down") ; ]
-+SC01B:: ScrollTo("down", 4) ; TODO not working
+#SC01B:: ScrollTo("down", 4) ; win + ]
 SC016:: ScrollTo("up", 4) ; u
 End:: Click("Up") ;! What is this?
 

--- a/mouse-control.ahk
+++ b/mouse-control.ahk
@@ -1,12 +1,11 @@
-#InstallKeybdHook
+#Requires AutoHotkey v2.0
+InstallKeybdHook
 
 ; vim_mouse_2.ahk
 ; vim (and now also WASD!) bindings to control the mouse with the keyboard
-; 
+;
 ; Astrid Ivy
 ; 2019-04-14
-;
-; Last updated 2022-02-05
 
 global INSERT_MODE := false
 global INSERT_QUICK := false
@@ -14,12 +13,8 @@ global NORMAL_MODE := false
 global NORMAL_QUICK := false
 global WASD := true
 
-; Drag takes care of this now
-;global MAX_VELOCITY := 72
-
-; mouse speed variables
-global FORCE := 1.8
-global RESISTANCE := 0.982
+global MOUSE_FORCE := 1.8
+global MOUSE_RESISTANCE := 0.982
 
 global VELOCITY_X := 0
 global VELOCITY_Y := 0
@@ -28,302 +23,330 @@ global POP_UP := false
 
 global DRAGGING := false
 
-; Insert Mode by default
-EnterInsertMode()
-
 Accelerate(velocity, pos, neg) {
-  If (pos == 0 && neg == 0) {
-    Return 0
-  }
-  ; smooth deceleration :)
-  Else If (pos + neg == 0) {
-    Return velocity * 0.666
-  }
-  ; physicszzzzz
-  Else {
-    Return velocity * RESISTANCE + FORCE * (pos + neg)
-  }
+    if (pos == 0 && neg == 0) {
+        return 0
+    }
+    ; smooth deceleration
+    else if (pos + neg == 0) {
+        return velocity * 0.666
+    }
+    ; physics
+    else {
+        return velocity * MOUSE_RESISTANCE + MOUSE_FORCE * (pos + neg)
+    }
 }
 
 MoveCursor() {
-  LEFT := 0
-  DOWN := 0
-  UP := 0
-  RIGHT := 0
-  
-  LEFT := LEFT - GetKeyState("h", "P")
-  DOWN := DOWN + GetKeyState("j", "P")
-  UP := UP - GetKeyState("k", "P")
-  RIGHT := RIGHT + GetKeyState("l", "P")
-  
-  if (WASD) {
-    UP := UP -  GetKeyState("w", "P")
-    LEFT := LEFT - GetKeyState("a", "P")
-    DOWN := DOWN + GetKeyState("s", "P")
-    RIGHT := RIGHT + GetKeyState("d", "P")
-  }
-  
-  If (NORMAL_QUICK) {
-    caps_down := GetKeyState("Capslock", "P")
-    IF (caps_down == 0) {
-      EnterInsertMode()
+    LEFT := 0
+    DOWN := 0
+    UP := 0
+    RIGHT := 0
+
+    LEFT := LEFT - GetKeyState("h", "P")
+    DOWN := DOWN + GetKeyState("j", "P")
+    UP := UP - GetKeyState("k", "P")
+    RIGHT := RIGHT + GetKeyState("l", "P")
+
+    if (WASD) {
+        UP := UP - GetKeyState("w", "P")
+        LEFT := LEFT - GetKeyState("a", "P")
+        DOWN := DOWN + GetKeyState("s", "P")
+        RIGHT := RIGHT + GetKeyState("d", "P")
     }
-  }
-  
-  If (NORMAL_MODE == false) {
-    VELOCITY_X := 0
-    VELOCITY_Y := 0
-    SetTimer,, Off
-  }
-  
-  VELOCITY_X := Accelerate(VELOCITY_X, LEFT, RIGHT)
-  VELOCITY_Y := Accelerate(VELOCITY_Y, UP, DOWN)
 
-  RestoreDPI:=DllCall("SetThreadDpiAwarenessContext","ptr",-3,"ptr") ; enable per-monitor DPI awareness
+    if (NORMAL_QUICK) {
+        caps_down := GetKeyState("Capslock", "P")
 
-  MouseMove, %VELOCITY_X%, %VELOCITY_Y%, 0, R
+        if (caps_down == 0) {
+            EnterInsertMode()
+        }
+    }
 
-  ;(humble beginnings)
-  ;MsgBox, %NORMAL_MODE%
-  ;msg1 := "h " . LEFT . " j  " . DOWN . " k " . UP . " l " . RIGHT
-  ;MsgBox, %msg1%
-  ;msg2 := "Moving " . VELOCITY_X . " " . VELOCITY_Y
-  ;MsgBox, %msg2%
+    if (NORMAL_MODE == false) {
+        VELOCITY_X := 0
+        VELOCITY_Y := 0
+
+        SetTimer(, Off)
+    }
+
+    VELOCITY_X := Accelerate(VELOCITY_X, LEFT, RIGHT)
+    VELOCITY_Y := Accelerate(VELOCITY_Y, UP, DOWN)
+
+    ; enable per-monitor DPI awareness
+    RestoreDPI := DllCall("SetThreadDpiAwarenessContext", "ptr", -3, "ptr")
+
+    MouseMove(%VELOCITY_X%, %VELOCITY_Y%, 0, R)
+
+    ;(humble beginnings)
+    ;MsgBox, %NORMAL_MODE%
+    ;msg1 := "h " . LEFT . " j  " . DOWN . " k " . UP . " l " . RIGHT
+    ;MsgBox, %msg1%
+    ;msg2 := "Moving " . VELOCITY_X . " " . VELOCITY_Y
+    ;MsgBox, %msg2%
 }
 
-EnterNormalMode(quick:=false) {
-  ;MsgBox, "Welcome to Normal Mode"
-  NORMAL_QUICK := quick
+EnterNormalMode(quick := false) {
+    ;MsgBox, "Welcome to Normal Mode"
+    NORMAL_QUICK := quick
 
-  msg := "NORMAL"
-  If (WASD == false) {
-    msg := msg . " (VIM)"
-  }
-  If (quick) {
-    msg := msg . " (QUICK)"
-  }
-  ShowModePopup(msg)
+    msg := "NORMAL"
 
-  If (NORMAL_MODE) {
-    Return
-  }
-  NORMAL_MODE := true
-  INSERT_MODE := false
-  INSERT_QUICK := false
+    if (WASD == false) {
+        msg := msg . " (VIM)"
+    }
 
-  SetTimer, MoveCursor, 16
+    if (quick) {
+        msg := msg . " (QUICK)"
+    }
+
+    ShowModePopup(msg)
+
+    if (NORMAL_MODE) {
+        return
+    }
+
+    NORMAL_MODE := true
+    INSERT_MODE := false
+    INSERT_QUICK := false
+
+    SetTimer(MoveCursor, 16)
 }
 
-EnterWASDMode(quick:=false) {
-  msg := "NORMAL"
-  If (quick) {
-    msg := msg . " (QUICK)"
-  }
-  ShowModePopup(msg)
-  WASD := true
-  EnterNormalMode(quick)
+EnterWASDMode(quick := false) {
+    msg := "NORMAL"
+
+    if (quick) {
+        msg := msg . " (QUICK)"
+    }
+
+    ShowModePopup(msg)
+
+    WASD := true
+
+    EnterNormalMode(quick)
 }
 
 ExitWASDMode() {
-  ShowModePopup("NORMAL (VIM)")
-  WASD := false
+    ShowModePopup("NORMAL (VIM)")
+    WASD := false
 }
 
-EnterInsertMode(quick:=false) {
-  ;MsgBox, "Welcome to Insert Mode"
-  msg := "INSERT"
-  If (quick) {
-    msg := msg . " (QUICK)"
-  }
-  ShowModePopup(msg)
-  INSERT_MODE := true
-  INSERT_QUICK := quick
-  NORMAL_MODE := false
-  NORMAL_QUICK := false
+EnterInsertMode(quick := false) {
+    ;MsgBox, "Welcome to Insert Mode"
+    msg := "INSERT"
+
+    if (quick) {
+        msg := msg . " (QUICK)"
+    }
+
+    ShowModePopup(msg)
+
+    INSERT_MODE := true
+    INSERT_QUICK := quick
+    NORMAL_MODE := false
+    NORMAL_QUICK := false
 }
 
-ClickInsert(quick:=true) {
-  Click
-  EnterInsertMode(quick)
+ClickInsert(quick := true) {
+    Click
+    EnterInsertMode(quick)
 }
 
-; FIXME:
+; TODO
 ; doesn't really work well
-DoubleClickInsert(quick:=true) {
-  Click
-  Sleep, 100
-  Click
-  EnterInsertMode(quick)
+DoubleClickInsert(quick := true) {
+    Click
+    Sleep(100)
+    Click
+    EnterInsertMode(quick)
 }
 
 ShowModePopup(msg) {
-  ; clean up any lingering popups
-  ClosePopup()
-  center := MonitorLeftEdge() + (A_ScreenWidth // 2)
-  popx := center - 150
-  popy := (A_ScreenHeight // 2) - 28
-  Progress, b x%popx% y%popy% zh0 w300 h56 fm24,, %msg%,,SimSun
-  SetTimer, ClosePopup, -1600
-  POP_UP := true
+    ; clean up any lingering popups
+    ClosePopup()
+
+    center := MonitorLeftEdge() + (A_ScreenWidth // 2)
+    popX := center - 150
+    popY := (A_ScreenHeight // 2) - 28
+
+    Progress(b x%popX% y%popY% zh0 w300 h56 fm24, , %msg%, , SimSun)
+    SetTimer(ClosePopup, -1600)
+
+    POP_UP := true
 }
 
 ClosePopup() {
-  Progress, Off
-  POP_UP := false
+    Progress(Off)
+    POP_UP := false
 }
 
 Drag() {
-  If (DRAGGING) {
-    Click, Left, Up
-    DRAGGING := false
-  } else {
-    Click, Left, Down
-    DRAGGING := true
-  }
+    if (DRAGGING) {
+        Click(Left, Up)
+        DRAGGING := false
+    }
+    else {
+        Click(Left, Down)
+        DRAGGING := true
+    }
 }
 
 RightDrag() {
-  If (DRAGGING) {
-    Click, Right, Up
-    DRAGGING := false
-  } else {
-    Click, Right, Down
-    DRAGGING := true
-  }
+    if (DRAGGING) {
+        Click(Right, Up)
+        DRAGGING := false
+    }
+    else {
+        Click(Right, Down)
+        DRAGGING := true
+    }
 }
 
 MiddleDrag() {
-  If (DRAGGING) {
-    Click, Middle, Up
-    DRAGGING := false
-  } else {
-    Send, {MButton down}
-    DRAGGING := true
-  }
+    if (DRAGGING) {
+        Click(Middle, Up)
+        DRAGGING := false
+    }
+    else {
+        Send("{ MButton down }")
+        DRAGGING := true
+    }
 }
 
 ReleaseDrag(button) {
-  Click, Middle, Up
-  Click, button
-  DRAGGING := false
+    Click(Middle, Up)
+    Click(button)
+
+    DRAGGING := false
 }
 
 Yank() {
-  wx := 0
-  wy := 0
-  width := 0
-  WinGetPos,wx,wy,width,,A
-  center := wx + width - 180
-  y := wy + 12
-  ;MsgBox, Hello %width% %center%
-  MouseMove, center, y
-  Drag()
+    wx := 0
+    wy := 0
+    width := 0
+
+    WinGetPos(wx, wy, width, , A)
+
+    center := wx + width - 180
+    y := wy + 12
+
+    ;MsgBox, Hello %width% %center%
+    MouseMove(center, y)
+    Drag()
 }
 
 MouseLeft() {
-  Click
-  DRAGGING := false
+    Click()
+    DRAGGING := false
 }
 
 MouseRight() {
-  Click, Right
-  DRAGGING := false
+    Click(Right)
+    DRAGGING := false
 }
 
 MouseMiddle() {
-  Click, Middle
-  DRAGGING := false
+    Click(Middle)
+    DRAGGING := false
 }
 
 ; TODO: When we have more monitors, set up H and L to use current screen as basis
 ; hard to test when I only have the one
 
 JumpMiddle() {
-  CoordMode, Mouse, Screen
-  MouseMove, (A_ScreenWidth // 2), (A_ScreenHeight // 2)
+    CoordMode(Mouse, Screen)
+    MouseMove(A_ScreenWidth // 2, A_ScreenHeight // 2)
 }
 
 JumpMiddle2() {
-  CoordMode, Mouse, Screen
-  MouseMove, (A_ScreenWidth + A_ScreenWidth // 2), (A_ScreenHeight // 2)
+    CoordMode(Mouse, Screen)
+    MouseMove(A_ScreenWidth + A_ScreenWidth // 2, A_ScreenHeight // 2)
 }
 
 JumpMiddle3() {
-  CoordMode, Mouse, Screen
-  MouseMove, (A_ScreenWidth * 2 + A_ScreenWidth // 2), (A_ScreenHeight // 2)
+    CoordMode(Mouse, Screen)
+    MouseMove(A_ScreenWidth * 2 + A_ScreenWidth // 2, A_ScreenHeight // 2)
 }
 
 MonitorLeftEdge() {
-  mx := 0
-  CoordMode, Mouse, Screen
-  MouseGetPos, mx
-  monitor := (mx // A_ScreenWidth)
+    mx := 0
 
-  return monitor * A_ScreenWidth
+    CoordMode(Mouse, Screen)
+    MouseGetPos(mx)
+
+    monitor := (mx // A_ScreenWidth)
+
+    return monitor * A_ScreenWidth
 }
 
 JumpLeftEdge() {
-  x := MonitorLeftEdge() + 2
-  y := 0
-  CoordMode, Mouse, Screen
-  MouseGetPos,,y
-  MouseMove, x,y
+    x := MonitorLeftEdge() + 2
+    y := 0
+
+    CoordMode(Mouse, Screen)
+    MouseGetPos(, y)
+    MouseMove(x, y)
 }
 
 JumpBottomEdge() {
-  x := 0
-  CoordMode, Mouse, Screen
-  MouseGetPos, x
-  MouseMove, x,(A_ScreenHeight - 0)
+    x := 0
+
+    CoordMode(Mouse, Screen)
+    MouseGetPos(x)
+    MouseMove(x, A_ScreenHeight - 0)
 }
 
 JumpTopEdge() {
-  x := 0
-  CoordMode, Mouse, Screen
-  MouseGetPos, x
-  MouseMove, x,0
+    x := 0
+
+    CoordMode(Mouse, Screen)
+    MouseGetPos(x)
+    MouseMove(x, 0)
 }
 
 JumpRightEdge() {
-  x := MonitorLeftEdge() + A_ScreenWidth - 2
-  y := 0
-  CoordMode, Mouse, Screen
-  MouseGetPos,,y
-  MouseMove, x,y
+    x := MonitorLeftEdge() + A_ScreenWidth - 2
+    y := 0
+
+    CoordMode(Mouse, Screen)
+    MouseGetPos(, y)
+    MouseMove(x, y)
 }
 
 MouseBack() {
-  Click, X1
+    Click(X1)
 }
 
 MouseForward() {
-  Click, X2
+    Click(X2)
 }
 
 ScrollUp() {
-  Click, WheelUp
+    Click(WheelUp)
 }
 
 ScrollDown() {
-  Click, WheelDown
+    Click(WheelDown)
 }
 
 ScrollUpMore() {
-  Click, WheelUp
-  Click, WheelUp
-  Click, WheelUp
-  Click, WheelUp
-  Return
+    Click(WheelUp)
+    Click(WheelUp)
+    Click(WheelUp)
+    Click(WheelUp)
+
+    return
 }
 
 ScrollDownMore() {
-  Click, WheelDown
-  Click, WheelDown
-  Click, WheelDown
-  Click, WheelDown
-  Return
-}
+    Click(WheelDown)
+    Click(WheelDown)
+    Click(WheelDown)
+    Click(WheelDown)
 
+    return
+}
 
 ; "FINAL" MODE SWITCH BINDINGS
 Home:: EnterNormalMode()
@@ -332,132 +355,132 @@ Insert:: EnterInsertMode()
 <#<!i:: EnterInsertMode()
 
 ; escape hatches
-+Home:: Send, {Home}
-+Insert:: Send, {Insert}
-;FIXME
-; doesn't turn caplsock off.
-^Capslock:: Send, {Capslock}
++Home:: Send("{ Home }")
++Insert:: Send("{ Insert }")
+
+; TODO doesn't turn capslock off.
+; ^Capslock:: Send, { Capslock }
 ; meh. good enough.
-^+Capslock:: SetCapsLockState, Off
+; ^+Capslock:: SetCapsLockState, Off
 
+#HotIf (NORMAL_MODE)
++`:: ClickInsert(false) ; focus window and enter Insert
+`:: ClickInsert(true) ; path to Quick Insert
+~f:: EnterInsertMode(true) ; passthru for Vimium hotlinks
+~^f:: EnterInsertMode(true) ; passthru to common "search" hotkey
+~^t:: EnterInsertMode(true) ; passthru for new tab
+~Delete:: EnterInsertMode(true) ; passthru for quick edits
++;:: EnterInsertMode(true) ; do not pass thru
+h:: return ; intercept movement keys
+j:: return
+k:: return
+l:: return
++H:: JumpLeftEdge()
++J:: JumpBottomEdge()
++K:: JumpTopEdge()
++L:: JumpRightEdge()
+*i:: MouseLeft() ; commands
+*o:: MouseRight()
+*p:: MouseMiddle()
++Y:: Yank() ; do not conflict with y as in "scroll up"
+v:: Drag()
+z:: RightDrag()
+c:: MiddleDrag()
++M:: JumpMiddle()
++,:: JumpMiddle2()
++.:: JumpMiddle3()
+m:: JumpMiddle() ; ahh what the heck, remove shift requirements for jump bindings
+,:: JumpMiddle2() ; maybe take "m" back if we ever make marks
+.:: JumpMiddle3()
+n:: MouseForward()
+b:: MouseBack()
+u:: ScrollUpMore() ; allow for modifier keys (or more importantly a lack of them) by lifting ctrl requirement for these hotkeys
+*0:: ScrollDown()
+*9:: ScrollUp()
+]:: ScrollDown()
+[:: ScrollUp()
++]:: ScrollDownMore()
++[:: ScrollUpMore()
+End:: Click(Up)
 
-#If (NORMAL_MODE)
-  ; focus window and enter Insert
-  +`:: ClickInsert(false)
-  ; path to Quick Insert
-  `:: ClickInsert(true)
-  ; passthru for Vimium hotlinks 
-  ~f:: EnterInsertMode(true)
-  ; passthru to common "search" hotkey
-  ~^f:: EnterInsertMode(true)
-  ; passthru for new tab
-  ~^t:: EnterInsertMode(true)
-  ; passthru for quick edits
-  ~Delete:: EnterInsertMode(true)
-  ; do not pass thru
-  +;:: EnterInsertMode(true)
-  ; intercept movement keys
-  h:: Return
-  j:: Return
-  k:: Return
-  l:: Return
-  +H:: JumpLeftEdge()
-  +J:: JumpBottomEdge()
-  +K:: JumpTopEdge()
-  +L:: JumpRightEdge()
-  ; commands
-  *i:: MouseLeft()
-  *o:: MouseRight()
-  *p:: MouseMiddle()
-  ; do not conflict with y as in "scroll up"
-  +Y:: Yank()
-  v:: Drag()
-  z:: RightDrag()
-  c:: MiddleDrag()
-  +M:: JumpMiddle()
-  +,:: JumpMiddle2()
-  +.:: JumpMiddle3()
-  ; ahh what the heck, remove shift requirements for jump bindings
-  ; maybe take "m" back if we ever make marks
-  m:: JumpMiddle()
-  ,:: JumpMiddle2()
-  .:: JumpMiddle3()
-  n:: MouseForward()
-  b:: MouseBack()
-  ; allow for modifier keys (or more importantly a lack of them) by lifting ctrl requirement for these hotkeys
-  u:: ScrollUpMore()
-  *0:: ScrollDown()
-  *9:: ScrollUp()
-  ]:: ScrollDown()
-  [:: ScrollUp()
-  +]:: ScrollDownMore()
-  +[:: ScrollUpMore()
-  End:: Click, Up
-#If (NORMAL_MODE && NORMAL_QUICK == false)
-  Capslock:: EnterInsertMode(true)
-  +Capslock:: EnterInsertMode()
-; Addl Vim hotkeys that conflict with WASD mode
-#If (NORMAL_MODE && WASD == false)
-  <#<!r:: EnterWASDMode()
-  e:: ScrollDown()
-  y:: ScrollUp()
-  d:: ScrollDownMore()
-  +S:: DoubleClickInsert()
+#HotIf (NORMAL_MODE && NORMAL_QUICK == false)
+Capslock:: EnterInsertMode(true)
++Capslock:: EnterInsertMode()
+
+; Add Vim hotkeys that conflict with WASD mode
+#HotIf (NORMAL_MODE && WASD == false)
+<#<!r:: EnterWASDMode()
+e:: ScrollDown()
+y:: ScrollUp()
+d:: ScrollDownMore()
++S:: DoubleClickInsert()
+
 ; No shift requirements in normal quick mode
-#If (NORMAL_MODE && NORMAL_QUICK)
-  Capslock:: Return
-  m:: JumpMiddle()
-  ,:: JumpMiddle2()
-  .:: JumpMiddle3()
-  y:: Yank()
-  ; for windows explorer
-#If (NORMAL_MODE && WinActive("ahk_class CabinetWClass"))
-  ^h:: Send {Left}
-  ^j:: Send {Down}
-  ^k:: Send {Up}
-  ^l:: Send {Right}
-#If (INSERT_MODE)
-  ; Normal (Quick) Mode
-#If (INSERT_MODE && INSERT_QUICK == false)
-  Capslock:: EnterNormalMode(true)
-  +Capslock:: EnterNormalMode()
-#If (INSERT_MODE && INSERT_QUICK)
-  ~Enter:: EnterNormalMode()
-  ; Copy and return to Normal Mode
-  ~^c:: EnterNormalMode()
-  Escape:: EnterNormalMode()
-  Capslock:: EnterNormalMode()
-  +Capslock:: EnterNormalMode()
-#If (NORMAL_MODE && WASD)
-  <#<!r:: ExitWASDMode()
-  ; Intercept movement keys
-  w:: Return
-  a:: Return
-  s:: Return
-  d:: Return
-  +C:: JumpMiddle()
-  +W:: JumpTopEdge()
-  +A:: JumpLeftEdge()
-  +S:: JumpBottomEdge()
-  +D:: JumpRightEdge()
-  *e:: ScrollDown()
-  *q:: ScrollUp()
-  *r:: MouseLeft()
-  t:: MouseRight()
-  +T:: MouseRight()
-  *y:: MouseMiddle()
-#IF (DRAGGING)
-  LButton:: ReleaseDrag(1)
-  MButton:: ReleaseDrag(2)
-  RButton:: ReleaseDrag(3)
-#If (POP_UP)
-  Escape:: ClosePopup()
-#If
+#HotIf (NORMAL_MODE && NORMAL_QUICK)
+Capslock:: return
+m:: JumpMiddle()
+,:: JumpMiddle2()
+.:: JumpMiddle3()
+y:: Yank()
+
+; for windows explorer
+#HotIf (NORMAL_MODE && WinActive("ahk_class CabinetWClass"))
+^h:: Send("{ Left }")
+^j:: Send("{ Down }")
+^k:: Send("{ Up }")
+^l:: Send("{ Right }")
+
+#HotIf (INSERT_MODE && INSERT_QUICK == false)
+Capslock:: EnterNormalMode(true)
++Capslock:: EnterNormalMode()
+
+#HotIf (INSERT_MODE && INSERT_QUICK)
+~Enter:: EnterNormalMode()
+~^c:: EnterNormalMode() ; Copy and return to Normal Mode
+Escape:: EnterNormalMode()
+Capslock:: EnterNormalMode()
++Capslock:: EnterNormalMode()
+
+#HotIf (NORMAL_MODE && WASD)
+<#<!r:: ExitWASDMode()
+w:: return ; Intercept movement keys
+a:: return
+s:: return
+d:: return
++C:: JumpMiddle()
++W:: JumpTopEdge()
++A:: JumpLeftEdge()
++S:: JumpBottomEdge()
++D:: JumpRightEdge()
+*e:: ScrollDown()
+*q:: ScrollUp()
+*r:: MouseLeft()
+t:: MouseRight()
++T:: MouseRight()
+*y:: MouseMiddle()
+
+#HotIf (DRAGGING)
+LButton:: ReleaseDrag(1)
+MButton:: ReleaseDrag(2)
+RButton:: ReleaseDrag(3)
+
+#HotIf (POP_UP)
+Escape:: ClosePopup()
+
+; Insert Mode by default
+EnterInsertMode()
 
 ; FUTURE CONSIDERATIONS
 ; AwaitKey function for vimesque multi keystroke commands (gg, yy, 2M, etc)
 ; "Marks" for remembering and restoring mouse positions (needs AwaitKey)
 ; v to let go of mouse when mouse is down with v (lemme crop in Paint.exe)
 ; z for click and release middle mouse? this has historically not worked well
-; c guess that leaves c for hold / release right mouse (x is useful in chronmium)
+; c guess that leaves c for hold / release right mouse (x is useful in chromium)
 ; Whatever you can think of! Github issues and pull requests welcome
+
+; РЕКОМЕНДАЦИИ НА БУДУЩЕЕ
+; Функция AwaitKey для команд vimesque с несколькими нажатиями клавиш (gg, yy, 2M и т.д.)
+; "Метки" для запоминания и восстановления положения мыши (требуется клавиша ожидания)
+; v, чтобы отпустить мышь, когда она нажата с помощью клавиши v (давайте обрежем в Paint.exe)
+; z для нажатия и отпускания средней кнопки мыши? исторически это не очень хорошо работало
+; c, полагаю, остается c для удержания / отпускания правой кнопки мыши (x полезно в chromium)

--- a/mouse-control.ahk
+++ b/mouse-control.ahk
@@ -174,14 +174,14 @@ Drag(mouseButton := "L") {
 ;     DRAGGING := false
 ; }
 
-; Yank() {
-;     wx := 0, wy := 0, width := 0
-;     WinGetPos(&wx, &wy, &width, , "A")
-;     center := wx + width - 180
-;     y := wy + 12
-;     MouseMove(center, y)
-;     Drag()
-; }
+Yank() {
+    wx := 0, wy := 0, width := 0
+    WinGetPos(&wx, &wy, &width, , "A")
+    center := wx + width - 180
+    y := wy + 12
+    MouseMove(center, y)
+    Drag()
+}
 
 EmulateMouseButton(button := "L") {
     ; If the key is held down, should simulate holding down the mouse key. Otherwise, it's letting up.
@@ -335,8 +335,7 @@ SC026:: return ; l
 *SC018 Up:: EmulateMouseButton("R") ; o
 *SC019:: EmulateMouseButton("M") ; p
 *SC019 Up:: EmulateMouseButton("M") ; p
-; shift + y, do not conflict with y as in  "scroll up"
-; +SC015:: Yank()  ;! It is unclear why this is necessary.
++SC015:: Yank() ; shift + y, do not conflict with y as in  "scroll up"
 SC02F:: Drag() ; v
 SC02C:: Drag("R") ; z
 SC02E:: Drag("M") ; c
@@ -369,7 +368,6 @@ Capslock:: return
 SC032:: JumpMiddle() ; m
 ; ,:: JumpMiddle2() ;! It is unclear why this is necessary.
 ; .:: JumpMiddle3() ;! It is unclear why this is necessary.
-; y:: Yank() ;! It is unclear why this is necessary.
 
 ;* for windows explorer
 #HotIf (INPUT_MODE.type != CONTROL_TYPE_NAME_INSERT && WinActive("ahk_class CabinetWClass"))

--- a/mouse-control.ahk
+++ b/mouse-control.ahk
@@ -167,13 +167,6 @@ Drag(mouseButton := "L") {
     DRAGGING := true
 }
 
-; ReleaseDrag(button) {
-;     Click("Middle Up")
-;     Click(button)
-
-;     DRAGGING := false
-; }
-
 Yank() {
     wx := 0, wy := 0, width := 0
     WinGetPos(&wx, &wy, &width, , "A")
@@ -202,15 +195,6 @@ JumpMiddle() {
     CoordMode("Mouse", "Screen")
     MouseMove(A_ScreenWidth // 2, A_ScreenHeight // 2)
 }
-
-; JumpMiddle2() {
-;     CoordMode("Mouse", "Screen")
-;     MouseMove(A_ScreenWidth + A_ScreenWidth // 2, A_ScreenHeight // 2)
-; }
-; JumpMiddle3() {
-;     CoordMode("Mouse", "Screen")
-;     MouseMove(A_ScreenWidth * 2 + A_ScreenWidth // 2, A_ScreenHeight // 2)
-; }
 
 GetMonitorLeftEdge() {
     mx := 0
@@ -340,8 +324,6 @@ SC02F:: Drag() ; v
 SC02C:: Drag("R") ; z
 SC02E:: Drag("M") ; c
 SC032:: JumpMiddle() ; m
-; SC033:: JumpMiddle2() ;! It is unclear why this is necessary.
-; SC034:: JumpMiddle3() ;! It is unclear why this is necessary.
 SC031:: MouseBrowserNavigate("forward") ; n
 SC030:: MouseBrowserNavigate("back") ; b
 ; TODO allow for modifier keys (or more importantly a lack of them) by lifting ctrl requirement for these hotkeys
@@ -350,7 +332,6 @@ SC030:: MouseBrowserNavigate("back") ; b
 *SC00B:: ScrollTo("down") ; 0
 SC01A:: ScrollTo("up") ; [
 SC01B:: ScrollTo("down") ; ]
-; End:: Click("Up") ;! What is this?
 
 #HotIf (INPUT_MODE.type != CONTROL_TYPE_NAME_INSERT && !INPUT_MODE.quick)
 Capslock:: EnterInsertMode(true)
@@ -358,7 +339,6 @@ Capslock:: EnterInsertMode(true)
 
 ;* Add Vim hotkeys that conflict with WASD mode
 #HotIf (INPUT_MODE.type == CONTROL_TYPE_NAME_VIM)
-; <#<!r:: EnterWASDMode() ;! Conflicts with the recording mode of Windows game bar
 SC015:: ScrollTo("up") ; y
 SC012:: ScrollTo("down") ; e
 ; +SC01F:: DoubleClickInsert() ; shift + s ; TODO doesn't really work well?
@@ -366,8 +346,6 @@ SC012:: ScrollTo("down") ; e
 #HotIf (INPUT_MODE.type != CONTROL_TYPE_NAME_INSERT && INPUT_MODE.quick)
 Capslock:: return
 SC032:: JumpMiddle() ; m
-; ,:: JumpMiddle2() ;! It is unclear why this is necessary.
-; .:: JumpMiddle3() ;! It is unclear why this is necessary.
 
 ;* for windows explorer
 #HotIf (INPUT_MODE.type != CONTROL_TYPE_NAME_INSERT && WinActive("ahk_class CabinetWClass"))
@@ -391,7 +369,6 @@ Capslock:: EnterNormalMode()
 +Capslock:: EnterNormalMode()
 
 #HotIf (INPUT_MODE.type == CONTROL_TYPE_NAME_WASD)
-; <#<!r:: ExitWASDMode() ;! Conflicts with the recording mode of Windows game bar
 ;* Intercept movement keys
 SC011:: return ; w
 SC01E:: return ; a
@@ -411,11 +388,6 @@ SC014:: EmulateMouseButton("R") ; t
 *SC015:: EmulateMouseButton("M") ; y
 *SC015 Up:: EmulateMouseButton("M") ; y
 ~BackSpace:: EnterInsertMode(true) ; passthrough for quick edits
-
-; #HotIf (DRAGGING) ;! It looks like broken code.
-; LButton:: ReleaseDrag(1)
-; MButton:: ReleaseDrag(2)
-; RButton:: ReleaseDrag(3)
 
 ; TODO: "Marks" for remembering and restoring mouse positions (needs AwaitKey)
 ; ?TODO: z for click and release middle mouse? this has historically not worked well

--- a/mouse-control.ahk
+++ b/mouse-control.ahk
@@ -260,8 +260,8 @@ Insert:: EnterInsertMode()
 +Insert:: Send("{Insert}")
 
 ; TODO doesn't turn capslock off.
-; ^Capslock:: Send, { Capslock }
-; ^+Capslock:: SetCapsLockState, Off
+^Capslock:: Send("{ Capslock }")
+^+Capslock:: SetCapsLockState("Off")
 
 #HotIf (NORMAL_MODE)
 +SC029:: ClickInsert(false) ; shift + tilde, focus window and enter Insert

--- a/mouse-control.ahk
+++ b/mouse-control.ahk
@@ -63,6 +63,7 @@ MoveCursor() {
         INPUT_MODE.quick &&
         !GetKeyState("Capslock", "P")
     ) {
+        ; If the fast mode is active, it switches back when release the key.
         EnterInsertMode()
     }
 
@@ -90,9 +91,15 @@ MoveCursor() {
 }
 
 EnterNormalMode(quick := false, mode := CONTROL_TYPE_NAME_VIM) {
-    INPUT_MODE.type := mode
-    INPUT_MODE.quick := quick
+    ;
+    if (INPUT_MODE.quick) {
+        INPUT_MODE.type := previousInputType
+    }
+    else {
+        INPUT_MODE.type := mode
+    }
 
+    INPUT_MODE.quick := quick
     msg := "MOUSE"
 
     msg := INPUT_MODE.type == CONTROL_TYPE_NAME_VIM
@@ -109,6 +116,10 @@ EnterInsertMode(quick := false) {
     msg := quick ? "INSERT (QUICK)" : "INSERT"
 
     ShowModePopup(msg)
+
+    if (quick) {
+        global previousInputType := INPUT_MODE.type
+    }
 
     INPUT_MODE.type := CONTROL_TYPE_NAME_INSERT
     INPUT_MODE.quick := quick
@@ -368,9 +379,10 @@ SC032:: JumpMiddle() ; m
 ^SC026:: Send("{ Right }") ; ctrl + l
 
 #HotIf (INPUT_MODE.type == CONTROL_TYPE_NAME_INSERT && !INPUT_MODE.quick)
+; TODO: this key activates only the mode for VIМ, need an option for WASD.
 Capslock:: EnterNormalMode(true)
 +Capslock:: EnterNormalMode()
-<+Space:: EnterNormalMode(, "wasd")
+<+Space:: EnterNormalMode(, CONTROL_TYPE_NAME_WASD)
 >+Space:: EnterNormalMode()
 
 #HotIf (INPUT_MODE.type == CONTROL_TYPE_NAME_INSERT && INPUT_MODE.quick)

--- a/mouse-control.ahk
+++ b/mouse-control.ahk
@@ -1,4 +1,5 @@
 #Requires AutoHotkey v2.0
+#SingleInstance
 InstallKeybdHook
 
 ; vim_mouse_2.ahk
@@ -169,8 +170,14 @@ Drag(mouseButton := "L") {
 ;     Drag()
 ; }
 
-MouseClick(button := "L") {
-    Click(button)
+EmulateMouseButton(button := "L") {
+    ; If the key is held down, should simulate holding down the mouse key. Otherwise, it's letting up.
+    if (InStr(A_ThisHotkey, "Up")) {
+        Click(button " Up")
+    }
+    else {
+        Click(button " Down")
+    }
 
     global DRAGGING := false
 }
@@ -258,7 +265,7 @@ DoByDoublePress(callback, repeatFor := 1) {
         return
     }
 
-    ;? Implements scrolling N-times with a double tap.
+    ;? Implements an action for N-times with a double tap.
     ; Initially, A_TimeSincePriorHotkey and A_PriorHotkey are empty strings.
     ; Using an empty string in a comparison is an error.
     ; Try prevents this initial inevitable error.
@@ -309,9 +316,12 @@ SC025:: return ; k
 SC026:: return ; l
 +SC026:: JumpToEdge("right")
 ; ? commands
-*SC017:: MouseClick() ; i
-*SC018:: MouseClick("R") ; o
-*SC019:: MouseClick("M") ; p
+*SC017:: EmulateMouseButton() ; i
+*SC017 Up:: EmulateMouseButton() ; i
+*SC018:: EmulateMouseButton("R") ; o
+*SC018 Up:: EmulateMouseButton("R") ; o
+*SC019:: EmulateMouseButton("M") ; p
+*SC019 Up:: EmulateMouseButton("M") ; p
 ; shift + y, do not conflict with y as in  "scroll up"
 ; +SC015:: Yank()  ;! It is unclear why this is necessary.
 SC02F:: Drag() ; v
@@ -382,9 +392,12 @@ SC020:: return ; d
 +SC020:: JumpToEdge("right") ; shift + d
 SC012:: ScrollTo("down") ; e
 *SC010:: ScrollTo("up") ; q
-*SC013:: MouseClick() ; r
-SC014:: MouseClick("R") ; t
-*SC015:: MouseClick("M") ; y
+*SC013:: EmulateMouseButton() ; r
+*SC013 Up:: EmulateMouseButton() ; r
+SC014:: EmulateMouseButton("R") ; t
+*SC014 Up:: EmulateMouseButton("R") ; t
+*SC015:: EmulateMouseButton("M") ; y
+*SC015 Up:: EmulateMouseButton("M") ; y
 ~BackSpace:: EnterInsertMode(true) ; passthrough for quick edits
 
 ; #HotIf (DRAGGING) ;! It looks like broken code.
@@ -393,7 +406,6 @@ SC014:: MouseClick("R") ; t
 ; RButton:: ReleaseDrag(3)
 
 ; TODO: "Marks" for remembering and restoring mouse positions (needs AwaitKey)
-; TODO: v to let go of mouse when mouse is down with v (lemme crop in Paint.exe)
 ; ?TODO: z for click and release middle mouse? this has historically not worked well
 ; ?TODO: c guess that leaves c for hold / release right mouse (x is useful in chromium)
 ;


### PR DESCRIPTION
I wanted to add better keyboard shortcuts for switching, but...

- Added compatibility with third-party keyboard layouts such as Dvorak, Zubachev layout and qphyx. This was achieved by using **SC-codes** instead of strict binding to letters.
- The code has been optimized (_I understand that the script was written a long time ago, but it was terrible_) and reduced by about 20%.
- Adapted for AHK 2.0
- The notification window has been improved, and the Windows tray is now used.
- Incorrectly working keyboard shortcuts have been redesigned to enable **normal WASD** (`<+Space`) and **normal VIM** (`>+Space`) mode.
- The hotkeys _not listed_ in the README are disabled (moreover, it was not clear to me why they were needed at all).